### PR TITLE
Search getFirstProduct start to 0

### DIFF
--- a/Trustpilot/viewLoader.php
+++ b/Trustpilot/viewLoader.php
@@ -110,7 +110,7 @@ class TrustpilotViewLoader
     public function getFirstProduct()
     {
         $lang = $this->getLanguageId();
-        $products = Product::getProducts($lang, 1, 1, 'id_product', 'ASC', false, true);
+        $products = Product::getProducts($lang, 0, 1, 'id_product', 'ASC', false, true);
         $firstProduct = $products[0];
         $product_id = $firstProduct['id_product'];
         $product = new Product($product_id, false, $lang);


### PR DESCRIPTION
In the function getFirstProduct of the viewLoader.php, change the second param "start" of the prestashop Product::getProducts(...) to 0 instead of 1.

Try to have only one product in you shop store, and you will get an error.
For now, with start 1, you will get the second element, and not the first.